### PR TITLE
set the list of services to stop to empty list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,8 +23,8 @@ certbot_create_arguments: >-
   --email={{ certbot_admin_email }}
   --domains={{ cert_item.domains | join(',') }}
 
-certbot_services_to_stop:
-  - nginx
+certbot_services_to_stop: []
+# - nginx
 # - apache
 
 certbot_containers_to_stop: []


### PR DESCRIPTION
If certbot is ran in the container - nginx is not required.