### PR TITLE
certbot: update certificate ownership

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,3 +47,5 @@ certbot_auto_renew_restart: 'on-abnormal'
 certbot_auto_renew_restart_mode: 'direct'
 certbot_auto_renew_restart_delay: 60
 certbot_auto_renew_restart_retries: 3
+# certbot_auto_renew_user:
+certbot_auto_renew_group: '{{certbot_auto_renew_user | default(certbot_docker_cont_uid)}}'

--- a/templates/certbot.sh.j2
+++ b/templates/certbot.sh.j2
@@ -9,3 +9,7 @@ exec docker run -i --rm \
   -p '80:80/tcp' -p '443:443/tcp' \
   '{{ certbot_docker_cont_image }}' \
   "$@"
+
+{% if certbot_auto_renew_user is defined %}
+chown -R {{ certbot_auto_renew_user }}:{{ certbot_auto_renew_group }} {{ certbot_config_dir }} 
+{% endif %}


### PR DESCRIPTION
Update certificate ownership after renewall to avoid permission issue.


Cannot be done by changing `certbot_docker_cont_uid` in some case: 
```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to setup user: cannot set uid to unmapped user in user namespace: unknown.
```

Linked to :
* https://github.com/status-im/infra-ci/pull/140