### PR TITLE
renew: add ExecStopPost

### DIFF
--- a/tasks/renew.yml
+++ b/tasks/renew.yml
@@ -23,3 +23,6 @@
     systemd_timer_exec_start_post: |
       {{ (["docker start "]    | product(certbot_containers_to_stop) | map("join")) +
          (["systemctl start "] | product(certbot_services_to_stop)   | map("join")) }}
+    systemd_timer_exec_stop_post: |
+      {{ (["docker start "]    | product(certbot_containers_to_stop) | map("join")) +
+         (["systemctl start "] | product(certbot_services_to_stop)   | map("join")) }}


### PR DESCRIPTION
Preventing services from staying down when certbot renewal fails.